### PR TITLE
Customize client context-path at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # pick base image
 FROM node:12.19.0-alpine3.12 as frontend-build-env
 
+# customize build-time context path
+ARG PUBLIC_URL
+
 # copy frontend source project
 COPY vedaweb-frontend /vedaweb-frontend
 
@@ -11,7 +14,7 @@ WORKDIR /vedaweb-frontend
 
 # build frontend
 RUN npm install --silent &> /dev/null \
- && npm run build
+ && ${PUBLIC_URL:+env PUBLIC_URL=$PUBLIC_URL} npm run build
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:12.19.0-alpine3.12 as frontend-build-env
 
 # customize build-time context path
-ARG PUBLIC_URL
+ARG PUBLIC_URL=/rigveda/
 
 # copy frontend source project
 COPY vedaweb-frontend /vedaweb-frontend
@@ -14,7 +14,7 @@ WORKDIR /vedaweb-frontend
 
 # build frontend
 RUN npm install --silent &> /dev/null \
- && ${PUBLIC_URL:+env PUBLIC_URL=$PUBLIC_URL} npm run build
+ && npm run build
 
 
 


### PR DESCRIPTION
This pull request introduces the `PUBLIC_URL` build arg. When set, this argument overwrites the default context path specified in the [`package.json#homepage`](https://github.com/schlusslicht/vedaweb/blob/feat/craco-context-path/vedaweb-frontend/package.json#L6) field, thereby allowing the frontend application to be deployed to different context( path)s.