### PR TITLE
Update elasticsearch components and enable compat mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cd vedaweb-backend \
 FROM adoptopenjdk/openjdk11:jre-11.0.8_10-alpine
 
 # set encoding and locales
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' ELASTIC_CLIENT_APIVERSIONING=true
 
 # ensure www-data user exists
 RUN set -x \

--- a/vedaweb-backend/pom.xml
+++ b/vedaweb-backend/pom.xml
@@ -25,7 +25,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>11</java.version>
-		<elasticsearch.version>7.6.2</elasticsearch.version>
+		<elasticsearch.version>7.17.24</elasticsearch.version>
 	</properties>
 
 
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>7.6.2</version><!--$NO-MVN-MAN-VER$ -->
+			<version>7.17.24</version><!--$NO-MVN-MAN-VER$ -->
 		</dependency>
 
 		<!-- <dependency> <groupId>org.elasticsearch.client</groupId> <artifactId>elasticsearch-rest-client</artifactId> 

--- a/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/IndexService.java
+++ b/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/IndexService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -38,6 +37,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilde
 import org.elasticsearch.search.aggregations.metrics.Cardinality;
 import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
This pull request updates the [`org.elasticsearch/elasticsearch`](https://mvnrepository.com/artifact/org.elasticsearch/elasticsearch) and [`org.elasticsearch.client/elasticsearch-rest-high-level-client`](https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-high-level-client) Maven dependencies to their latest minor release version, introduces a small compatability fix, and enables the ElasticSearch v7/v8 compatability mode by introducing the [`ELASTIC_CLIENT_APIVERSIONING`](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/migration.html#migration-compat-mode) environment variable.