### PR TITLE
Use configured index name, if available

### DIFF
--- a/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/CommonSearchData.java
+++ b/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/CommonSearchData.java
@@ -48,14 +48,6 @@ public abstract class CommonSearchData {
 	@Schema(description = "List of meta properties to filter for")
 	private Map<String, String[]> meta;
 	
-	
-	/*
-	 * This will have to be refactored for a generic
-	 * version of the platform!
-	 */
-	private String indexName = "vedaweb";
-	
-	
 	public CommonSearchData(){
 		sortBy = "_score";
 		sortOrder = "descend";
@@ -131,7 +123,7 @@ public abstract class CommonSearchData {
 	
 	
 	public String getIndexName() {
-		return indexName;
+		return IndexService.indexName;
 	}
 
 }


### PR DESCRIPTION
This pull request removes all hardcoded occurances of the ElasticSearch index name and replaces them with a reference to the pseudo-dependency-injected static variable [`IndexService.indexName`](https://github.com/schlusslicht/vedaweb/blob/feat/generic-index-name/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/IndexService.java#L71). This violates a major design pattern regarding dependency injection, as it introduces a race condition between the [late/lazy injection of the dependency](https://github.com/schlusslicht/vedaweb/blob/feat/generic-index-name/vedaweb-backend/src/main/java/de/unikoeln/vedaweb/search/IndexService.java#L87-L92) and access to said static variable, which can cause undefined behaviour and application crashes. **But** instead makes this app more configurable, in this case.